### PR TITLE
Add missing public dir for Express

### DIFF
--- a/Server/public/README.md
+++ b/Server/public/README.md
@@ -1,0 +1,1 @@
+Static files for Express are served from this directory.


### PR DESCRIPTION
## Summary
- add `Server/public` directory required by `express.static`

## Testing
- `npm test` in `Server` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6851299c39208321a52d914eb5e51939